### PR TITLE
Set response type to blob when fetching image

### DIFF
--- a/lib/commandsExecute.js
+++ b/lib/commandsExecute.js
@@ -15,12 +15,17 @@ var OscError = require('./OscError')
 // OSC COMMANDS EXECUTE
 var commandsRequest = function (name, params, callback) {
   var commandsExecuteUrl = this.serverAddress + '/osc/commands/execute'
-  request.post(commandsExecuteUrl)
+  const req = request.post(commandsExecuteUrl)
     .type('json')
     .send({ name: name, parameters: params })
     .set('Content-Type', 'application/json; charset=utf-8')
     .set('X-XSRF-Protected', '1')
-    .end(callback)
+
+  if (name === 'camera.getImage') {
+    req.responseType('blob')
+  }
+
+  req.end(callback)
 }
 
 var commandsExecute = function (name, params, statusCallback) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "q": "^1.4.1",
-    "superagent": "^1.4.0"
+    "superagent": "^3.0.0"
   },
   "devDependencies": {
     "@bubltechnology/eslint-config-bubl": "^2.0.1",


### PR DESCRIPTION
According to the superagent's [docs](https://visionmedia.github.io/superagent/#binary) it is necessary to set the XHR `responseType` while running in browser environments.